### PR TITLE
Set default nginx worker_processes parameter to 1 instead of 'auto'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,7 @@
 # run as a less privileged user for security reasons.
 nginx_user: www-data
 # auto or a number
-nginx_worker_processes: auto
+nginx_worker_processes: 1
 nginx_worker_connections: 768
 # default settings
 nginx_sendfile: 'on'


### PR DESCRIPTION
The auto parameter is not available in older versions of nginx, [see here](http://nginx.org/en/docs/ngx_core_module.html#worker_processes).