### PR TITLE
Allow setting certificate path per site

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ Here is a list of all the default variables for this role, which are also availa
 #     aliases: []
 #     redirects: []
 #     ssl:
+#       cert_path: /etc/letsencrypt/live/sub.example.com
 #       port: 443
-#       key_name: mykey
-#       cert_name: mycert
+#       key_name: mykey.key
+#       cert_name: mycert.crt
 #     rules: []
 #     auth:
 #       name: foo

--- a/templates/etc-nginx-sites-available-site/body.j2
+++ b/templates/etc-nginx-sites-available-site/body.j2
@@ -13,8 +13,8 @@ server {
   # --- ssl -------------------------------------------------------------------
   include rules/ssl.conf;
 
-  ssl_certificate {{ openssl_certs_path }}/{{ item.ssl.cert_name|default('server') }}.crt;
-  ssl_certificate_key {{ openssl_keys_path }}/{{ item.ssl.key_name|default('server') }}.key;
+  ssl_certificate {{ item.ssl.cert_path |default(openssl_certs_path) }}/{{ item.ssl.cert_name|default('server.crt') }};
+  ssl_certificate_key {{ item.ssl.cert_path |default(openssl_keys_path) }}/{{ item.ssl.key_name|default('server.key') }};
   {% endif %}
 
   {% if item.rules is defined %}

--- a/templates/etc-nginx-sites-available-site/redirect.j2
+++ b/templates/etc-nginx-sites-available-site/redirect.j2
@@ -11,8 +11,8 @@ server {
 
   include rules/ssl.conf;
 
-  ssl_certificate {{ openssl_certs_path }}/{{ item.ssl.cert_name|default('server') }}.crt;
-  ssl_certificate_key {{ openssl_keys_path }}/{{ item.ssl.key_name|default('server') }}.key;
+  ssl_certificate {{ item.ssl.cert_path |default(openssl_certs_path) }}/{{ item.ssl.cert_name|default('server.crt') }};
+  ssl_certificate_key {{ item.ssl.cert_path |default(openssl_keys_path) }}/{{ item.ssl.key_name|default('server.key') }};
   {% endif %}
 
   # --- redirects --------------------------------------------------------------


### PR DESCRIPTION
This change also includes a side effect that the .key and .crt extensions
become mandatory parts of key_name and cert_name. Unfortunately this makes the
commit a breaking change with previous versions where people may have been
assuming the previous behaviour.

This facilitates (among other things) support for Letsencrypt rather than
relying on a self signed / commercial CA setup and system wide configuration.